### PR TITLE
Fix mobile move navigation placement on analysis pages

### DIFF
--- a/src/hooks/useScreenSize.ts
+++ b/src/hooks/useScreenSize.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { SIDEBAR_WIDTH } from "@/sections/layout/Sidebar";
 
 const MOBILE_HEADER = 52;
+/** Move nav row shown below the board on mobile analysis pages */
+export const MOBILE_MOVE_NAV_HEIGHT = 52;
 /** Fixed right panel width on desktop (Chessigma-style) */
 export const ANALYSIS_PANEL_WIDTH = 400;
 /** Rigid player bar height (top + bottom of board column) */
@@ -53,7 +55,11 @@ export const getAnalysisBoardSize = (
 
   const maxByWidth = screenWidth - EVAL_BAR_TOTAL - 16;
   const maxByHeight =
-    screenHeight - MOBILE_HEADER - PLAYER_BAR_HEIGHT * 2 - 24;
+    screenHeight -
+    MOBILE_HEADER -
+    PLAYER_BAR_HEIGHT * 2 -
+    MOBILE_MOVE_NAV_HEIGHT -
+    24;
 
   return Math.max(240, Math.floor(Math.min(maxByWidth, maxByHeight)));
 };

--- a/src/sections/analysis/AnalysisPageLayout.tsx
+++ b/src/sections/analysis/AnalysisPageLayout.tsx
@@ -105,6 +105,22 @@ export default function AnalysisPageLayout({
         </Box>
 
         <PlayerBar position="bottom" />
+
+        {/* Mobile: keep move controls next to the board, not at the end of the report */}
+        {panelFooter && (
+          <Box
+            sx={{
+              display: { xs: "block", md: "none" },
+              flexShrink: 0,
+              px: { xs: 1, sm: 1.25 },
+              py: 1,
+              bgcolor: palette.surface,
+              borderTop: `1px solid ${palette.border}`,
+            }}
+          >
+            {panelFooter}
+          </Box>
+        )}
       </Box>
 
       {/* Right panel: fixed width, full height */}
@@ -171,6 +187,7 @@ export default function AnalysisPageLayout({
         {panelFooter && (
           <Box
             sx={{
+              display: { xs: "none", md: "block" },
               pt: 1,
               mt: "auto",
               flexShrink: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On mobile, the game report panel sits below the board and can grow very tall. Move controls (`AnalysisBottomNav`) were rendered at the bottom of that panel, so users had to scroll through the entire report before they could step through moves — and could not see the board and controls at the same time.

This change keeps the **desktop layout unchanged** and moves the nav bar **directly under the board** on small screens only.

## Changes

- **`AnalysisPageLayout`**: render `panelFooter` below the board column on `xs`/`sm`, and keep it in the right panel footer on `md+`
- **`useScreenSize`**: subtract `MOBILE_MOVE_NAV_HEIGHT` when calculating analysis board size on mobile so the board still fits above the new nav row

## Testing

- Verified at 375×812 mobile viewport on `/#/reanalysis`
- Move nav appears directly below the board without scrolling
- No duplicate nav at the bottom of the report panel
- Prev/next buttons work correctly
- Desktop layout unchanged

[Mobile layout with board and nav visible together](https://cursor.com/agents/bc-05745bc4-7559-4f8e-ad54-9f48b577064e/artifacts?path=%2Ftmp%2Fcomputer-use%2Ff0cae.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

