### PR TITLE
Classroom join codes: fix add-student flow for coaches

### DIFF
--- a/backend/academies/admin.py
+++ b/backend/academies/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Academy, CoachStudentLink, Membership
+from .models import Academy, Classroom, CoachStudentLink, Membership
 
 
 @admin.register(Academy)
@@ -17,3 +17,10 @@ class MembershipAdmin(admin.ModelAdmin):
 @admin.register(CoachStudentLink)
 class CoachStudentLinkAdmin(admin.ModelAdmin):
     list_display = ("coach", "student", "academy", "created_at")
+
+
+@admin.register(Classroom)
+class ClassroomAdmin(admin.ModelAdmin):
+    list_display = ("name", "coach", "join_code", "is_active", "updated_at")
+    list_filter = ("is_active",)
+    search_fields = ("join_code", "coach__username", "name")

--- a/backend/academies/classroom_codes.py
+++ b/backend/academies/classroom_codes.py
@@ -1,0 +1,47 @@
+import secrets
+import string
+
+from django.db import IntegrityError
+
+AMBIGUOUS = frozenset("O0IL1")
+ALPHABET = "".join(
+    c for c in (string.ascii_uppercase + string.digits) if c not in AMBIGUOUS
+)
+
+
+def normalize_join_code(raw: str) -> str:
+    """Normalize user input: trim, uppercase, ensure VC- prefix."""
+    code = (raw or "").strip().upper().replace(" ", "")
+    if code and not code.startswith("VC-"):
+        code = f"VC-{code.removeprefix('VC')}"
+    return code
+
+
+def generate_join_code() -> str:
+    from .models import Classroom
+
+    for _ in range(32):
+        suffix = "".join(secrets.choice(ALPHABET) for _ in range(6))
+        code = f"VC-{suffix}"
+        if not Classroom.objects.filter(join_code=code).exists():
+            return code
+    raise RuntimeError("Could not generate a unique classroom join code")
+
+
+def get_or_create_classroom_for_coach(coach):
+    from .models import Classroom
+
+    classroom, created = Classroom.objects.get_or_create(
+        coach=coach,
+        defaults={"join_code": generate_join_code(), "name": f"{coach.username}'s classroom"},
+    )
+    if created:
+        return classroom
+    if not classroom.join_code:
+        classroom.join_code = generate_join_code()
+        try:
+            classroom.save(update_fields=["join_code", "updated_at"])
+        except IntegrityError:
+            classroom.join_code = generate_join_code()
+            classroom.save(update_fields=["join_code", "updated_at"])
+    return classroom

--- a/backend/academies/classroom_serializers.py
+++ b/backend/academies/classroom_serializers.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+from .models import Classroom
+
+
+class ClassroomSerializer(serializers.ModelSerializer):
+    coach_username = serializers.CharField(source="coach.username", read_only=True)
+    student_count = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Classroom
+        fields = (
+            "id",
+            "name",
+            "join_code",
+            "is_active",
+            "coach_username",
+            "student_count",
+            "created_at",
+            "updated_at",
+        )
+        read_only_fields = (
+            "id",
+            "join_code",
+            "coach_username",
+            "student_count",
+            "created_at",
+            "updated_at",
+        )
+
+    def get_student_count(self, obj):
+        return obj.coach.students_coached.count()
+
+
+class ClassroomPreviewSerializer(serializers.Serializer):
+    join_code = serializers.CharField(max_length=20)
+
+
+class JoinClassroomSerializer(serializers.Serializer):
+    join_code = serializers.CharField(max_length=20)

--- a/backend/academies/migrations/0004_classroom.py
+++ b/backend/academies/migrations/0004_classroom.py
@@ -1,0 +1,46 @@
+# Generated manually — coach classroom join codes
+
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("academies", "0003_coachstudentlink_profile"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Classroom",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(default="My Classroom", max_length=200)),
+                ("join_code", models.CharField(db_index=True, max_length=12, unique=True)),
+                ("is_active", models.BooleanField(default=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "coach",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="classroom",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+    ]

--- a/backend/academies/models.py
+++ b/backend/academies/models.py
@@ -85,3 +85,25 @@ class CoachStudentLink(models.Model):
 
     def __str__(self):
         return f"{self.coach.username} → {self.student.username}"
+
+
+class Classroom(models.Model):
+    """A coach's classroom — students join with a unique code instead of username lookup."""
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    coach = models.OneToOneField(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="classroom",
+    )
+    name = models.CharField(max_length=200, default="My Classroom")
+    join_code = models.CharField(max_length=12, unique=True, db_index=True)
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.name} ({self.join_code})"

--- a/backend/academies/urls.py
+++ b/backend/academies/urls.py
@@ -4,6 +4,10 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     AcademyViewSet,
     CoachStudentLinkViewSet,
+    JoinClassroomView,
+    MyClassroomView,
+    PreviewClassroomJoinView,
+    RegenerateClassroomCodeView,
     StudentGamesView,
     StudentReportView,
     StudentStatsView,
@@ -15,6 +19,18 @@ router.register(r"coach-links", CoachStudentLinkViewSet, basename="coach-link")
 
 urlpatterns = [
     path("", include(router.urls)),
+    path("classroom/mine/", MyClassroomView.as_view(), name="classroom-mine"),
+    path(
+        "classroom/regenerate/",
+        RegenerateClassroomCodeView.as_view(),
+        name="classroom-regenerate",
+    ),
+    path(
+        "classroom/preview/",
+        PreviewClassroomJoinView.as_view(),
+        name="classroom-preview",
+    ),
+    path("classroom/join/", JoinClassroomView.as_view(), name="classroom-join"),
     path(
         "students/<uuid:student_id>/stats/",
         StudentStatsView.as_view(),

--- a/backend/academies/views.py
+++ b/backend/academies/views.py
@@ -1,8 +1,9 @@
 from django.contrib.auth import get_user_model
+from django.db import IntegrityError
 from django.shortcuts import get_object_or_404
 from rest_framework import generics, permissions, status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -10,7 +11,13 @@ from games.models import Game
 from games.serializers import GameListSerializer
 from games.stats import compute_student_report, compute_student_stats
 
-from .models import Academy, CoachStudentLink, Membership, MembershipRole
+from .classroom_codes import (
+    generate_join_code,
+    get_or_create_classroom_for_coach,
+    normalize_join_code,
+)
+from .classroom_serializers import ClassroomSerializer
+from .models import Academy, Classroom, CoachStudentLink, Membership, MembershipRole
 from .permissions import user_is_academy_admin
 from .serializers import (
     AcademySerializer,
@@ -92,15 +99,34 @@ class CoachStudentLinkViewSet(viewsets.ModelViewSet):
             raise PermissionDenied(
                 "Only coaches and admins can create coach–student links."
             )
-        student_username = self.request.data.get("student_username")
+
+        # Coaches must use classroom join codes — prevents linking the wrong account.
+        if user.role == User.UserRole.COACH:
+            raise PermissionDenied(
+                "Share your classroom join code instead. Students join from My Academy."
+            )
+
+        student_username = self.request.data.get("student_username", "").strip()
         student_id = self.request.data.get("student_id")
         if student_username:
-            student = get_object_or_404(User, username=student_username.strip())
+            student = User.objects.filter(username__iexact=student_username).first()
+            if not student:
+                raise ValidationError(
+                    {"student_username": f"No user found with username '{student_username}'."}
+                )
         else:
             student = get_object_or_404(User, pk=student_id)
-        if student.role != User.UserRole.STUDENT and user.role != User.UserRole.ADMIN:
+
+        if student.role != User.UserRole.STUDENT:
             raise PermissionDenied("Can only link student accounts.")
-        serializer.save(coach=user, student=student)
+
+        if CoachStudentLink.objects.filter(coach=user, student=student).exists():
+            raise ValidationError({"detail": "This student is already linked to you."})
+
+        try:
+            serializer.save(coach=user, student=student)
+        except IntegrityError:
+            raise ValidationError({"detail": "This student is already linked to you."})
 
 
 class StudentStatsView(APIView):
@@ -157,3 +183,143 @@ class StudentGamesView(generics.ListAPIView):
             elif user.role != User.UserRole.ADMIN:
                 return Game.objects.none()
         return Game.objects.filter(owner=student).select_related("eval")
+
+
+class MyClassroomView(APIView):
+    """Coach: get or create their classroom and join code."""
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def get(self, request):
+        user = request.user
+        if user.role not in (User.UserRole.COACH, User.UserRole.ADMIN):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        classroom = get_or_create_classroom_for_coach(user)
+        return Response(ClassroomSerializer(classroom).data)
+
+    def patch(self, request):
+        user = request.user
+        if user.role not in (User.UserRole.COACH, User.UserRole.ADMIN):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        classroom = get_or_create_classroom_for_coach(user)
+        name = request.data.get("name")
+        if name and isinstance(name, str):
+            classroom.name = name.strip()[:200]
+            classroom.save(update_fields=["name", "updated_at"])
+        if "is_active" in request.data:
+            classroom.is_active = bool(request.data["is_active"])
+            classroom.save(update_fields=["is_active", "updated_at"])
+        return Response(ClassroomSerializer(classroom).data)
+
+
+class RegenerateClassroomCodeView(APIView):
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        user = request.user
+        if user.role not in (User.UserRole.COACH, User.UserRole.ADMIN):
+            return Response(status=status.HTTP_403_FORBIDDEN)
+        classroom = get_or_create_classroom_for_coach(user)
+        classroom.join_code = generate_join_code()
+        classroom.save(update_fields=["join_code", "updated_at"])
+        return Response(ClassroomSerializer(classroom).data)
+
+
+class PreviewClassroomJoinView(APIView):
+    """Student: verify a join code and see which coach they will join."""
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        user = request.user
+        if user.role != User.UserRole.STUDENT:
+            return Response(
+                {"detail": "Only student accounts can join a classroom."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        code = normalize_join_code(request.data.get("join_code", ""))
+        if not code or len(code) < 5:
+            return Response(
+                {"detail": "Enter a valid classroom code (e.g. VC-ABC123)."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        classroom = Classroom.objects.filter(
+            join_code__iexact=code, is_active=True
+        ).select_related("coach").first()
+        if not classroom:
+            return Response(
+                {"detail": "No classroom found with that code. Check with your coach."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if classroom.coach_id == user.pk:
+            return Response(
+                {"detail": "You cannot join your own classroom."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        already = CoachStudentLink.objects.filter(
+            coach=classroom.coach, student=user
+        ).exists()
+
+        return Response(
+            {
+                "join_code": classroom.join_code,
+                "classroom_name": classroom.name,
+                "coach_username": classroom.coach.username,
+                "already_member": already,
+            }
+        )
+
+
+class JoinClassroomView(APIView):
+    """Student: join a coach's classroom after verifying the code."""
+
+    permission_classes = (permissions.IsAuthenticated,)
+
+    def post(self, request):
+        user = request.user
+        if user.role != User.UserRole.STUDENT:
+            return Response(
+                {"detail": "Only student accounts can join a classroom."},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        code = normalize_join_code(request.data.get("join_code", ""))
+        if not code:
+            return Response(
+                {"detail": "Classroom code is required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        classroom = Classroom.objects.filter(
+            join_code__iexact=code, is_active=True
+        ).select_related("coach").first()
+        if not classroom:
+            return Response(
+                {"detail": "Invalid or inactive classroom code."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if classroom.coach_id == user.pk:
+            return Response(
+                {"detail": "You cannot join your own classroom."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        link, created = CoachStudentLink.objects.get_or_create(
+            coach=classroom.coach,
+            student=user,
+        )
+
+        return Response(
+            {
+                "created": created,
+                "coach_username": classroom.coach.username,
+                "classroom_name": classroom.name,
+                "link_id": str(link.id),
+            },
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )

--- a/backend/accounts/management/commands/seed_demo.py
+++ b/backend/accounts/management/commands/seed_demo.py
@@ -1,7 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 
-from academies.models import Academy, CoachStudentLink, Membership, MembershipRole
+from academies.models import Academy, Classroom, CoachStudentLink, Membership, MembershipRole
+from academies.classroom_codes import get_or_create_classroom_for_coach
 from accounts.models import UserRole
 from assignments.models import Assignment, AssignmentStatus
 
@@ -53,6 +54,10 @@ class Command(BaseCommand):
             defaults={"academy": academy},
         )
 
+        classroom = get_or_create_classroom_for_coach(coach)
+        classroom.name = "VoltChess Demo Classroom"
+        classroom.save(update_fields=["name", "updated_at"])
+
         Assignment.objects.get_or_create(
             coach=coach,
             student=student,
@@ -66,3 +71,4 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Demo data ready:"))
         self.stdout.write(f"  Coach login:   coach / {DEMO_PASSWORD}")
         self.stdout.write(f"  Student login: student / {DEMO_PASSWORD}")
+        self.stdout.write(f"  Classroom code: {classroom.join_code}")

--- a/src/lib/api/classrooms.ts
+++ b/src/lib/api/classrooms.ts
@@ -1,0 +1,62 @@
+import api from "@/api";
+
+export type Classroom = {
+  id: string;
+  name: string;
+  join_code: string;
+  is_active: boolean;
+  coach_username: string;
+  student_count: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type ClassroomPreview = {
+  join_code: string;
+  classroom_name: string;
+  coach_username: string;
+  already_member: boolean;
+};
+
+export type JoinClassroomResult = {
+  created: boolean;
+  coach_username: string;
+  classroom_name: string;
+  link_id: string;
+};
+
+export async function fetchMyClassroom(): Promise<Classroom> {
+  const res = await api.get<Classroom>("/api/classroom/mine/");
+  return res.data;
+}
+
+export async function updateMyClassroom(data: {
+  name?: string;
+  is_active?: boolean;
+}): Promise<Classroom> {
+  const res = await api.patch<Classroom>("/api/classroom/mine/", data);
+  return res.data;
+}
+
+export async function regenerateClassroomCode(): Promise<Classroom> {
+  const res = await api.post<Classroom>("/api/classroom/regenerate/");
+  return res.data;
+}
+
+export async function previewClassroomJoin(
+  join_code: string
+): Promise<ClassroomPreview> {
+  const res = await api.post<ClassroomPreview>("/api/classroom/preview/", {
+    join_code,
+  });
+  return res.data;
+}
+
+export async function joinClassroom(
+  join_code: string
+): Promise<JoinClassroomResult> {
+  const res = await api.post<JoinClassroomResult>("/api/classroom/join/", {
+    join_code,
+  });
+  return res.data;
+}

--- a/src/pages/coach/index.tsx
+++ b/src/pages/coach/index.tsx
@@ -14,6 +14,7 @@ import { usePalette } from "@/hooks/usePalette";
 import { alpha } from "@mui/material/styles";
 import { fetchCoachDashboard } from "@/lib/api/coaching";
 import CoachShell from "@/sections/coach/CoachShell";
+import ClassroomPanel from "@/sections/coach/ClassroomPanel";
 import {
   CoachPageHeader,
   CoachStatCard,
@@ -40,6 +41,8 @@ export default function CoachDashboardPage() {
           title="Command Center"
           subtitle={`Welcome back, ${user?.username}. Your academy at a glance — students, workload, and who needs attention today.`}
         />
+
+        <ClassroomPanel />
 
         {isLoading ? (
           <CircularProgress />
@@ -228,7 +231,7 @@ export default function CoachDashboardPage() {
                 <CoachEmptyState
                   icon="mdi:account-plus-outline"
                   title="No students yet"
-                  description="Add students by username from the Students tab."
+                  description="Share your classroom code from the Students tab — students join from My Academy."
                 />
               ) : (
                 data.roster.slice(0, 8).map((r) => (

--- a/src/pages/coach/students.tsx
+++ b/src/pages/coach/students.tsx
@@ -17,15 +17,12 @@ import {
 import { Icon } from "@iconify/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import CoachShell from "@/sections/coach/CoachShell";
+import ClassroomPanel from "@/sections/coach/ClassroomPanel";
 import { CoachPageHeader, CoachEmptyState } from "@/sections/coach/CoachUi";
 import { engagementColor, PRIORITY_OPTIONS } from "@/sections/coach/constants";
 import { usePalette } from "@/hooks/usePalette";
 import { alpha } from "@mui/material/styles";
-import {
-  createCoachLink,
-  fetchCoachLinks,
-  updateCoachLink,
-} from "@/lib/api/academies";
+import { fetchCoachLinks, updateCoachLink } from "@/lib/api/academies";
 import { fetchCoachDashboard } from "@/lib/api/coaching";
 import NavLink from "@/components/NavLink";
 
@@ -34,8 +31,6 @@ export default function CoachStudentsPage() {
   const qc = useQueryClient();
   const [search, setSearch] = useState("");
   const [tagFilter, setTagFilter] = useState("");
-  const [addOpen, setAddOpen] = useState(false);
-  const [username, setUsername] = useState("");
   const [editId, setEditId] = useState<string | null>(null);
   const [notes, setNotes] = useState("");
   const [tags, setTags] = useState("");
@@ -46,16 +41,6 @@ export default function CoachStudentsPage() {
   const { data: dashboard, isLoading } = useQuery({
     queryKey: ["coach-dashboard"],
     queryFn: fetchCoachDashboard,
-  });
-
-  const addMut = useMutation({
-    mutationFn: () => createCoachLink({ student_username: username.trim() }),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ["coach-dashboard"] });
-      qc.invalidateQueries({ queryKey: ["coach-links"] });
-      setAddOpen(false);
-      setUsername("");
-    },
   });
 
   const updateMut = useMutation({
@@ -108,13 +93,10 @@ export default function CoachStudentsPage() {
       <CoachShell>
         <CoachPageHeader
           title="Student roster"
-          subtitle="Search, tag, and set goals. Pin priority students and track engagement without leaving the coach hub."
-          action={
-            <Button variant="contained" onClick={() => setAddOpen(true)}>
-              Add student
-            </Button>
-          }
+          subtitle="Share your classroom code so students can join from My Academy. Search, tag, and set goals for everyone on your roster."
         />
+
+        <ClassroomPanel />
 
         <Box sx={{ display: "flex", gap: 1.5, flexWrap: "wrap", mb: 2 }}>
           <TextField
@@ -147,7 +129,7 @@ export default function CoachStudentsPage() {
           <CoachEmptyState
             icon="mdi:account-search-outline"
             title="No students match"
-            description="Add a student by their VoltChess username or adjust filters."
+            description="Share your classroom code above, or adjust your search filters."
           />
         ) : (
           <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5 }}>
@@ -225,32 +207,6 @@ export default function CoachStudentsPage() {
             ))}
           </Box>
         )}
-
-        <Dialog open={addOpen} onClose={() => setAddOpen(false)} fullWidth maxWidth="xs">
-          <DialogTitle>Add student</DialogTitle>
-          <DialogContent>
-            <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
-              Enter the student&apos;s VoltChess username. They must already have registered.
-            </Typography>
-            <TextField
-              fullWidth
-              label="Username"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              size="small"
-            />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setAddOpen(false)}>Cancel</Button>
-            <Button
-              variant="contained"
-              disabled={!username.trim() || addMut.isPending}
-              onClick={() => addMut.mutate()}
-            >
-              Link student
-            </Button>
-          </DialogActions>
-        </Dialog>
 
         <Dialog open={!!editId} onClose={() => setEditId(null)} fullWidth maxWidth="sm">
           <DialogTitle>Student coaching profile</DialogTitle>

--- a/src/pages/student/index.tsx
+++ b/src/pages/student/index.tsx
@@ -8,6 +8,7 @@ import { fetchAssignments, updateAssignment } from "@/lib/api/assignments";
 import { fetchGames } from "@/lib/api/games";
 import { fetchCoachMessages } from "@/lib/api/coaching";
 import NavLink from "@/components/NavLink";
+import JoinClassroomCard from "@/sections/coach/JoinClassroomCard";
 import { prepareNewAnalysisSession } from "@/hooks/useAnalysisSession";
 import { useRouter } from "@/hooks/useRouter";
 
@@ -60,6 +61,8 @@ export default function StudentHome() {
         <Typography color="text.secondary" sx={{ mb: 3 }}>
           Welcome, {user?.username}. View assignments and your synced games.
         </Typography>
+
+        <JoinClassroomCard />
 
         <Box sx={{ ...cardSx, mb: 3 }}>
           <Typography variant="h6" fontWeight={600} sx={{ mb: 2 }}>

--- a/src/sections/coach/ClassroomPanel.tsx
+++ b/src/sections/coach/ClassroomPanel.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  CircularProgress,
+  IconButton,
+  TextField,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { usePalette } from "@/hooks/usePalette";
+import { alpha } from "@mui/material/styles";
+import {
+  fetchMyClassroom,
+  regenerateClassroomCode,
+  updateMyClassroom,
+} from "@/lib/api/classrooms";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+
+export default function ClassroomPanel() {
+  const palette = usePalette();
+  const qc = useQueryClient();
+  const [copied, setCopied] = useState(false);
+  const [nameEdit, setNameEdit] = useState<string | null>(null);
+
+  const { data: classroom, isLoading, error } = useQuery({
+    queryKey: ["my-classroom"],
+    queryFn: fetchMyClassroom,
+  });
+
+  const regenMut = useMutation({
+    mutationFn: regenerateClassroomCode,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["my-classroom"] });
+      setCopied(false);
+    },
+  });
+
+  const saveNameMut = useMutation({
+    mutationFn: (name: string) => updateMyClassroom({ name }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["my-classroom"] });
+      setNameEdit(null);
+    },
+  });
+
+  const copyCode = async () => {
+    if (!classroom?.join_code) return;
+    try {
+      await navigator.clipboard.writeText(classroom.join_code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  if (isLoading) return <CircularProgress size={28} />;
+
+  if (error) {
+    return (
+      <Alert severity="error" sx={{ mb: 2 }}>
+        {getApiErrorMessage(error)}
+      </Alert>
+    );
+  }
+
+  if (!classroom) return null;
+
+  const displayName = nameEdit ?? classroom.name;
+
+  return (
+    <Box
+      sx={{
+        p: 2.5,
+        mb: 3,
+        borderRadius: 2,
+        bgcolor: palette.surfaceRaised,
+        border: `1px solid ${alpha(palette.accent, 0.35)}`,
+        background: `linear-gradient(135deg, ${alpha(palette.accent, 0.08)} 0%, transparent 60%)`,
+      }}
+    >
+      <Box sx={{ display: "flex", alignItems: "flex-start", gap: 1.5, mb: 2 }}>
+        <Box
+          sx={{
+            width: 40,
+            height: 40,
+            borderRadius: 2,
+            display: "grid",
+            placeItems: "center",
+            bgcolor: alpha(palette.accent, 0.15),
+          }}
+        >
+          <Icon icon="mdi:school-outline" width={22} color={palette.accent} />
+        </Box>
+        <Box sx={{ flex: 1, minWidth: 0 }}>
+          <Typography fontWeight={800} fontSize="1.05rem">
+            Your classroom
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Share this code with students — they join from <strong>My Academy</strong> after
+            verifying your name. No more typing usernames.
+          </Typography>
+        </Box>
+        <Chip
+          label={classroom.is_active ? "Open" : "Closed"}
+          size="small"
+          color={classroom.is_active ? "success" : "default"}
+        />
+      </Box>
+
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", alignItems: "center", mb: 2 }}>
+        <TextField
+          size="small"
+          label="Classroom name"
+          value={displayName}
+          onChange={(e) => setNameEdit(e.target.value)}
+          sx={{ minWidth: 200, flex: 1 }}
+        />
+        {nameEdit !== null && nameEdit !== classroom.name && (
+          <Button
+            size="small"
+            variant="outlined"
+            disabled={saveNameMut.isPending}
+            onClick={() => saveNameMut.mutate(displayName.trim())}
+          >
+            Save name
+          </Button>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          gap: 1.5,
+          flexWrap: "wrap",
+          p: 2,
+          borderRadius: 2,
+          bgcolor: alpha(palette.bg, 0.6),
+          border: `1px dashed ${palette.border}`,
+        }}
+      >
+        <Typography
+          variant="h4"
+          fontWeight={800}
+          letterSpacing="0.12em"
+          sx={{ fontFamily: "monospace", color: palette.accent }}
+        >
+          {classroom.join_code}
+        </Typography>
+        <Tooltip title={copied ? "Copied!" : "Copy code"}>
+          <IconButton onClick={copyCode} size="small" aria-label="Copy classroom code">
+            <Icon icon={copied ? "mdi:check" : "mdi:content-copy"} width={20} />
+          </IconButton>
+        </Tooltip>
+        <Button
+          size="small"
+          variant="outlined"
+          disabled={regenMut.isPending}
+          onClick={() => regenMut.mutate()}
+          startIcon={<Icon icon="mdi:refresh" width={16} />}
+        >
+          New code
+        </Button>
+        <Typography variant="body2" color="text.secondary" sx={{ ml: "auto" }}>
+          {classroom.student_count} student{classroom.student_count === 1 ? "" : "s"} joined
+        </Typography>
+      </Box>
+
+      {regenMut.isError && (
+        <Alert severity="error" sx={{ mt: 1.5 }}>
+          {getApiErrorMessage(regenMut.error)}
+        </Alert>
+      )}
+    </Box>
+  );
+}

--- a/src/sections/coach/JoinClassroomCard.tsx
+++ b/src/sections/coach/JoinClassroomCard.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { Icon } from "@iconify/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { usePalette } from "@/hooks/usePalette";
+import { alpha } from "@mui/material/styles";
+import {
+  joinClassroom,
+  previewClassroomJoin,
+  type ClassroomPreview,
+} from "@/lib/api/classrooms";
+import { getApiErrorMessage } from "@/lib/apiErrors";
+
+export default function JoinClassroomCard() {
+  const palette = usePalette();
+  const qc = useQueryClient();
+  const [code, setCode] = useState("");
+  const [preview, setPreview] = useState<ClassroomPreview | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  const joinMut = useMutation({
+    mutationFn: () => joinClassroom(preview!.join_code),
+    onSuccess: (result) => {
+      setSuccessMsg(
+        result.created
+          ? `You joined ${result.coach_username}'s classroom!`
+          : `You're already in ${result.coach_username}'s classroom.`
+      );
+      setPreview(null);
+      setCode("");
+      qc.invalidateQueries({ queryKey: ["coach-links"] });
+      qc.invalidateQueries({ queryKey: ["assignments"] });
+    },
+  });
+
+  const handleVerify = async () => {
+    setPreviewError(null);
+    setSuccessMsg(null);
+    setPreview(null);
+    if (!code.trim()) {
+      setPreviewError("Enter your classroom code.");
+      return;
+    }
+    setChecking(true);
+    try {
+      const result = await previewClassroomJoin(code.trim());
+      setPreview(result);
+    } catch (err) {
+      setPreviewError(getApiErrorMessage(err));
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        p: 2.5,
+        mb: 3,
+        borderRadius: 2,
+        bgcolor: palette.surfaceRaised,
+        border: `1px solid ${palette.border}`,
+      }}
+    >
+      <Box sx={{ display: "flex", gap: 1.25, mb: 1.5, alignItems: "center" }}>
+        <Icon icon="mdi:school-outline" width={24} color={palette.accent} />
+        <Typography variant="h6" fontWeight={700}>
+          Join your coach&apos;s classroom
+        </Typography>
+      </Box>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Ask your coach for their classroom code (e.g. <strong>VC-ABC123</strong>). We&apos;ll
+        show you their name before you join — so you never connect to the wrong coach.
+      </Typography>
+
+      <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap", mb: 2 }}>
+        <TextField
+          size="small"
+          label="Classroom code"
+          placeholder="VC-ABC123"
+          value={code}
+          onChange={(e) => {
+            setCode(e.target.value.toUpperCase());
+            setPreview(null);
+            setPreviewError(null);
+          }}
+          sx={{ minWidth: 200, flex: 1 }}
+          inputProps={{ style: { fontFamily: "monospace", letterSpacing: "0.08em" } }}
+        />
+        <Button
+          variant="outlined"
+          disabled={checking || !code.trim()}
+          onClick={handleVerify}
+        >
+          {checking ? "Checking…" : "Verify code"}
+        </Button>
+      </Box>
+
+      {previewError && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {previewError}
+        </Alert>
+      )}
+
+      {successMsg && (
+        <Alert severity="success" sx={{ mb: 2 }} onClose={() => setSuccessMsg(null)}>
+          {successMsg}
+        </Alert>
+      )}
+
+      {preview && (
+        <Box
+          sx={{
+            p: 2,
+            borderRadius: 2,
+            bgcolor: alpha(palette.accent, 0.08),
+            border: `1px solid ${alpha(palette.accent, 0.3)}`,
+          }}
+        >
+          <Typography fontWeight={700} sx={{ mb: 0.5 }}>
+            {preview.already_member ? "Already enrolled" : "Confirm join"}
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 0.5 }}>
+            Classroom: <strong>{preview.classroom_name}</strong>
+          </Typography>
+          <Typography variant="body2" sx={{ mb: 1.5 }}>
+            Coach: <strong>{preview.coach_username}</strong>
+          </Typography>
+          <Typography variant="caption" color="text.secondary" display="block" sx={{ mb: 1.5 }}>
+            Code: {preview.join_code}
+          </Typography>
+          {!preview.already_member && (
+            <Button
+              variant="contained"
+              disabled={joinMut.isPending}
+              onClick={() => joinMut.mutate()}
+              startIcon={
+                joinMut.isPending ? (
+                  <CircularProgress size={16} color="inherit" />
+                ) : (
+                  <Icon icon="mdi:login" width={18} />
+                )
+              }
+            >
+              Join this classroom
+            </Button>
+          )}
+          {joinMut.isError && (
+            <Alert severity="error" sx={{ mt: 1.5 }}>
+              {getApiErrorMessage(joinMut.error)}
+            </Alert>
+          )}
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken **Add student** flow and replaces it with a safer **classroom join code** system.

### Problem
- Coaches typing usernames failed silently (no error UI) and used case-sensitive lookup.
- Easy to link the wrong student account by typo.

### Solution
- Each coach gets a unique classroom code (e.g. `VC-ABC123`).
- Students enter the code on **My Academy → Join your coach's classroom**.
- **Verify code** shows classroom name + coach username before joining.
- Coaches can copy/regenerate the code from **Command Center** or **Students** tab.

### Backend
- New `Classroom` model + migration `0004_classroom`
- Endpoints: `/api/classroom/mine/`, `preview/`, `join/`, `regenerate/`
- Coaches blocked from direct `POST /api/coach-links/` (admins still can)

### Deploy note (Pi)
After merging, on the Raspberry Pi:
```bash
cd backend && python manage.py migrate
sudo systemctl restart voltchess-api
```

### How to link jeevith
1. Coach opens **Students** tab and copies classroom code.
2. Student `jeevith` logs in → **My Academy** → enters code → **Verify** → **Join this classroom**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

