### PR TITLE
Fix 404 on page reload for SPA routes on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node scripts/postbuild-spa.mjs",
     "build:github": "tsc && vite build --config vite.config.github.ts",
     "build:static": "tsc && vite build --config vite.config.ts",
     "start": "vite preview",

--- a/scripts/postbuild-spa.mjs
+++ b/scripts/postbuild-spa.mjs
@@ -1,0 +1,13 @@
+import { copyFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+const indexPath = join("dist", "index.html");
+const fallbackPath = join("dist", "404.html");
+
+if (!existsSync(indexPath)) {
+  console.error("postbuild-spa: dist/index.html not found");
+  process.exit(1);
+}
+
+copyFileSync(indexPath, fallbackPath);
+console.log("postbuild-spa: copied index.html → 404.html for SPA deep links");

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,13 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
-  "framework": "vite",
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
+  "cleanUrls": false,
+  "trailingSlash": false,
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/.*", "dest": "/index.html" }
+  ],
   "headers": [
     {
       "source": "/(.*)",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig({
     },
   },
   // Vercel serves from domain root; "./" for other static hosts
-  base: process.env.VERCEL ? "/" : "./",
+  // Absolute paths in production so deep links (/coach/students) load assets correctly.
+  base: process.env.VERCEL || process.env.NODE_ENV === "production" ? "/" : "./",
   server: {
     port: 3000,
     headers: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Reloading or directly opening any client-side route (e.g. `/login`, `/coach/students`) on **www.voltchess.me** returned Vercel's `404: NOT_FOUND` page. Only `/` worked.

Confirmed in production: `curl -I https://www.voltchess.me/login` → 404.

## Cause

VoltChess is a React SPA with `BrowserRouter`. Vercel must serve `index.html` for unknown paths so the client router can handle the URL. The existing `rewrites` entry was present but not taking effect (common with the Vite framework preset / `cleanUrls` project settings).

## Fix

1. **`vercel.json`**: Switch to explicit `routes` with `filesystem` handle first, then catch-all to `/index.html`; set `cleanUrls: false`; remove `framework: vite` preset.
2. **Build post-step**: Copy `dist/index.html` → `dist/404.html` as a static fallback for unmatched paths.
3. **`vite.config.ts`**: Use absolute `/` base in all production builds so assets resolve correctly on deep links.

After merge + deploy, reloading any in-app route should load the app normally.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05745bc4-7559-4f8e-ad54-9f48b577064e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

