### PR TITLE
Fix platform game sync (Chess.com/Lichess) and post-login routing

### DIFF
--- a/backend/sync/platform_fetch.py
+++ b/backend/sync/platform_fetch.py
@@ -13,6 +13,19 @@ import requests
 SYNC_GAME_LIMIT = 30
 REQUEST_TIMEOUT = 25
 
+# Chess.com's public API is fronted by Cloudflare, which returns 403 ("Just a
+# moment…") for requests that do not send a real User-Agent. Lichess also asks
+# integrations to identify themselves. Always send a descriptive UA so imports
+# don't silently fail with "user not found".
+USER_AGENT = "VoltChess/1.0 (+https://voltchess.me; chess analysis academy)"
+
+
+def _get(url: str, *, headers: dict | None = None) -> requests.Response:
+    merged = {"User-Agent": USER_AGENT}
+    if headers:
+        merged.update(headers)
+    return requests.get(url, headers=merged, timeout=REQUEST_TIMEOUT)
+
 
 @dataclass
 class FetchedGame:
@@ -80,25 +93,34 @@ def _parse_chesscom_game(raw: dict) -> FetchedGame | None:
 
 def fetch_chesscom_games(username: str, limit: int = SYNC_GAME_LIMIT) -> list[FetchedGame]:
     username = username.strip().lower()
-    now = datetime.now(timezone.utc)
-    year = now.year
-    month = now.month
+
+    # Resolve the player's monthly archives instead of guessing the current /
+    # previous month: a player who hasn't played recently still imports their
+    # latest games, and empty months don't surface as spurious 404s.
+    archives_url = f"https://api.chess.com/pub/player/{username}/games/archives"
+    archives_resp = _get(archives_url)
+    if archives_resp.status_code == 404:
+        raise ValueError(f"Chess.com user '{username}' not found.")
+    if archives_resp.status_code >= 400:
+        raise ValueError(
+            f"Chess.com is unavailable right now (status {archives_resp.status_code})."
+        )
+
+    archives = (archives_resp.json() if archives_resp.content else {}).get(
+        "archives"
+    ) or []
 
     games: list[dict] = []
-
-    def fetch_month(y: int, m: int) -> None:
-        url = f"https://api.chess.com/pub/player/{username}/games/{y}/{m:02d}"
-        resp = requests.get(url, timeout=REQUEST_TIMEOUT)
+    # Newest month first; stop once we have enough games.
+    for archive_url in reversed(archives):
+        if len(games) >= limit:
+            break
+        resp = _get(archive_url)
+        if resp.status_code >= 400:
+            continue
         data = resp.json() if resp.content else {}
-        if resp.status_code >= 400 and data.get("message") != "Date cannot be set in the future":
-            raise ValueError(f"Chess.com user '{username}' not found or unavailable.")
-        games.extend(data.get("games") or [])
-
-    fetch_month(year, month)
-    if len(games) < limit:
-        prev_month = 12 if month == 1 else month - 1
-        prev_year = year - 1 if month == 1 else year
-        fetch_month(prev_year, prev_month)
+        month_games = data.get("games") or []
+        games.extend(month_games)
 
     parsed: list[FetchedGame] = []
     for raw in sorted(games, key=lambda g: g.get("end_time") or 0, reverse=True):
@@ -160,13 +182,13 @@ def fetch_lichess_games(username: str, limit: int = SYNC_GAME_LIMIT) -> list[Fet
         f"https://lichess.org/api/games/user/{username}"
         f"?max={limit}&pgnInJson=true&sort=dateDesc&clocks=true"
     )
-    resp = requests.get(
-        url,
-        headers={"Accept": "application/x-ndjson"},
-        timeout=REQUEST_TIMEOUT,
-    )
+    resp = _get(url, headers={"Accept": "application/x-ndjson"})
+    if resp.status_code == 404:
+        raise ValueError(f"Lichess user '{username}' not found.")
     if resp.status_code >= 400:
-        raise ValueError(f"Lichess user '{username}' not found or unavailable.")
+        raise ValueError(
+            f"Lichess is unavailable right now (status {resp.status_code})."
+        )
 
     parsed: list[FetchedGame] = []
     for line in resp.text.split("\n"):

--- a/src/components/GuestRoute.tsx
+++ b/src/components/GuestRoute.tsx
@@ -1,28 +1,39 @@
 import { ReactNode, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import { useRouter } from "@/hooks/useRouter";
 import { LoadingSpinner } from "@/components/Loading";
 import { useAuth } from "@/contexts/AuthContext";
 import { ENABLE_AUTHENTICATION } from "@/constants";
+import { landingForRole } from "@/lib/auth";
 
 interface GuestRouteProps {
   children: ReactNode;
+  /** Explicit override; otherwise redirect to the user's role home. */
   redirectTo?: string;
 }
 
-/** Auth pages — redirect signed-in users away (e.g. login → home). */
-export default function GuestRoute({
-  children,
-  redirectTo = "/",
-}: GuestRouteProps) {
+/** Auth pages — redirect signed-in users away (e.g. login → role dashboard). */
+export default function GuestRoute({ children, redirectTo }: GuestRouteProps) {
   const router = useRouter();
-  const { loading, isAuthenticated } = useAuth();
+  const location = useLocation();
+  const { loading, isAuthenticated, user } = useAuth();
 
   useEffect(() => {
     if (!ENABLE_AUTHENTICATION || loading) return;
     if (isAuthenticated) {
-      router.replace(redirectTo);
+      // Honor an explicit deep link the user was sent here from; otherwise drop
+      // them on their role's dashboard. Computed the same way as the login
+      // handler so the two redirects never fight over different destinations.
+      const from = (location.state as { from?: { pathname: string } })?.from
+        ?.pathname;
+      const target =
+        redirectTo ??
+        (from && from !== "/" && from !== "/login" && from !== "/register"
+          ? from
+          : landingForRole(user?.role));
+      router.replace(target);
     }
-  }, [loading, isAuthenticated, router, redirectTo]);
+  }, [loading, isAuthenticated, router, redirectTo, location.state, user]);
 
   if (ENABLE_AUTHENTICATION && loading) {
     return <LoadingSpinner message="Loading..." />;

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,17 @@
 import { ENABLE_AUTHENTICATION } from "@/constants";
 import { hasStoredSession } from "@/lib/authStorage";
+import { UserRole } from "@/types/user";
+
+/**
+ * Home route for a signed-in user based on their role. Used by both the login
+ * handler and `GuestRoute` so post-authentication redirects always agree (and
+ * never race each other to different destinations).
+ */
+export function landingForRole(role: UserRole | undefined): string {
+  if (role === UserRole.Student) return "/student";
+  if (role === UserRole.Coach || role === UserRole.Admin) return "/coach";
+  return "/";
+}
 
 /**
  * Check if user authentication is required and if user is authenticated

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -16,13 +16,7 @@ import { useRouter } from "@/hooks/useRouter";
 import { usePalette } from "@/hooks/usePalette";
 import AuthLayout from "@/sections/auth/AuthLayout";
 import { getApiErrorMessage } from "@/lib/apiErrors";
-import { UserRole } from "@/types/user";
-
-function landingForRole(role: UserRole): string {
-  if (role === UserRole.Student) return "/student";
-  if (role === UserRole.Coach || role === UserRole.Admin) return "/coach";
-  return "/";
-}
+import { landingForRole } from "@/lib/auth";
 
 function LoginForm() {
   const router = useRouter();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken Chess.com/Lichess game sync and a post-login routing bug.

## Walkthrough

Login lands on the student dashboard (`/student`) and connecting a Chess.com account now imports games into the hub:

[chesscom_sync_import_and_login_routing_demo.mp4](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchesscom_sync_import_and_login_routing_demo.mp4)

[After login: URL is /student with Chess.com games imported](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_login_student_hub.webp)
[After reload: still on /student, games persist](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_reload_student_hub_loaded.webp)

### 1. Platform sync was importing 0 games (`backend/sync/platform_fetch.py`)
- **Root cause:** requests to the Chess.com public API were sent with no `User-Agent`. Chess.com is fronted by Cloudflare, which returns **403 ("Just a moment…")** for those requests, so every import raised "Chess.com user not found or unavailable" and **nothing was saved** — which is also why synced games "disappeared" on reload (they were never created in the first place).
- **Fix:** send a descriptive `User-Agent` on all Chess.com/Lichess requests, and fetch Chess.com games via the player's `/games/archives` endpoint (newest month first, until the limit is reached) instead of guessing the current/previous month. This also handles players who haven't played this month and avoids spurious 404s.

Verified against a real account (`jitheshsarvin`): 0 → 30 games imported, analyzed, and persisted across reload.

### 2. After login, users landed on `/` instead of their dashboard (`src/components/GuestRoute.tsx`, `src/lib/auth.ts`, `src/pages/login.tsx`)
- **Root cause:** the login handler navigated to the role dashboard (`/student` or `/coach`) while `GuestRoute` simultaneously redirected authenticated users to a hardcoded `/`. The two navigations raced and `/` usually won.
- **Fix:** `GuestRoute` now redirects to a role-aware destination (honoring an explicit `from` deep link), computed via a shared `landingForRole()` helper used by both the login handler and `GuestRoute`, so they always agree.

## Notes
- Periodic auto-sync of new games and the "Analyze new → add to hub" flow already exist (`PlatformSyncOrchestrator`, `syncAnalysisResult`); they were effectively dead because the underlying import always failed. They now work with the sync fix.
- Session persistence on reload could not be reproduced in local dev — tokens persist in `localStorage` and the session is restored correctly (see screenshots). The reported logout is most likely tied to the ephemeral production Cloudflare tunnel URL changing between deploys rather than the frontend auth code.

## Testing
- `backend/.venv/bin/python backend/manage.py test sync` — 15 passed
- `npm run lint` — clean
- `npm run build` — succeeds
- Manual (recorded): logged in as `student`, landed on `/student`, connected Chess.com `jitheshsarvin`, imported 30 games that analyzed and persisted across reload.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

