### PR TITLE
Fix: stay signed in on reload when token refresh fails transiently

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -7,7 +7,6 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { isAxiosError } from "axios";
 import api, { refreshAccessToken } from "@/api";
 import { ENABLE_AUTHENTICATION } from "@/constants";
 import {
@@ -29,10 +28,6 @@ type AuthContextValue = {
 };
 
 const AuthContext = createContext<AuthContextValue | null>(null);
-
-function isAuthError(err: unknown): boolean {
-  return isAxiosError(err) && err.response?.status === 401;
-}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(() =>
@@ -60,15 +55,30 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setUser(cached);
     }
 
+    // Renew the access token up front when a refresh token is available. This
+    // keeps a reload from depending on a 401 → retry round-trip and, crucially,
+    // `refreshAccessToken` only clears the session when the refresh token
+    // itself is rejected (a real, permanent auth failure) — transient
+    // network/CORS errors leave the session intact.
+    await refreshAccessToken().catch(() => null);
+    if (!hasStoredSession()) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+
     try {
       const res = await api.get<User>("/api/me/");
       setUser(res.data);
       writeCachedUser(res.data);
-    } catch (err) {
-      if (isAuthError(err)) {
-        clearAuthStorage();
-        setUser(null);
-      } else if (!cached) {
+    } catch {
+      // We get here when `/api/me/` (and the interceptor's refresh retry) could
+      // not complete. Only sign the user out if the session was actually
+      // invalidated — i.e. the refresh token was rejected, which clears
+      // storage. Otherwise this is a transient failure (flaky backend/tunnel,
+      // offline, CORS hiccup); keep the cached session so a reload does not
+      // bounce an otherwise-valid user back to the login page.
+      if (!hasStoredSession() || !cached) {
         setUser(null);
       }
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes users being signed out and bounced to `/login` when they reload the page.

## Walkthrough

Part A: with a corrupted access token and the refresh path unavailable (simulating a flaky backend/tunnel dropping the refresh call), a reload now **stays** on the student hub. Part B: a genuinely cleared session still correctly routes to login.

[session_persists_on_reload_after_fix.mp4](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsession_persists_on_reload_after_fix.mp4)

Before vs after the same reload scenario:

[Before fix: reload bounced to /login](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_bounced_to_login.webp)
[After fix: reload stays on /student](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_stays_on_student_hub.webp)

## Root cause

On session restore, `AuthContext.refreshUser()` cleared the stored session (`clearAuthStorage()`) on **any** `401` from `/api/me` — including when the access token had merely expired and the follow-up token-refresh request failed **transiently** (flaky Pi/Cloudflare tunnel, CORS hiccup, brief offline). The backend itself is fine (valid tokens → 200, bad tokens → 401, refresh → 200); the logout was entirely client-side over-eager clearing.

## Fix (`src/contexts/AuthContext.tsx`)

- Proactively refresh the access token during session restore (so an expired-but-refreshable session is renewed without relying on a 401→retry round-trip).
- Only sign out when the session is **genuinely** invalidated — i.e. the refresh token itself is rejected, which clears storage. Transient `/api/me` failures now keep the cached session, so a reload no longer bounces an otherwise-valid user to `/login`.
- A real sign-out (cleared/expired refresh token) still routes to `/login` (verified in Part B).

## Notes
- The demo deliberately corrupts the access token and removes the refresh token to force the exact buggy path; the transient 401 errors/toast it shows are an artifact of that contrived setup. In the real transient case (valid refresh token, dropped request), the next successful refresh restores full functionality with no visible errors.

## Testing
- `npm run lint` — clean
- `npm run build` — succeeds
- `backend/.venv/bin/python backend/manage.py test sync` — 15 passed
- Manual (recorded): reload with a failed token refresh keeps the session on `/student`; `localStorage.clear()` + reload correctly shows `/login`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

