### PR TITLE
Fix analysis: open saved reports without re-analyzing; remove blocked cloud-eval; stop loop

### DIFF
--- a/src/hooks/useAnalyzeGame.ts
+++ b/src/hooks/useAnalyzeGame.ts
@@ -138,5 +138,9 @@ export function useAnalyzeGame() {
     gameEval,
     evaluationProgress,
     engineReady: !!engine?.getIsReady(),
+    // Synced games are analyzed once in the background and their report is
+    // saved on the server, so opening one should never kick off a fresh
+    // foreground analysis.
+    isServerGame: !!serverGameFromUrl,
   };
 }

--- a/src/hooks/useGameDatabase.ts
+++ b/src/hooks/useGameDatabase.ts
@@ -121,13 +121,19 @@ export const useGameDatabase = (shouldFetchGames?: boolean) => {
     if (typeof gameId !== "string") {
       setGameFromUrl(undefined);
       setServerGameFromUrl(undefined);
-      return;
+      return undefined;
     }
 
     if (isServerGameId(gameId)) {
       setGameFromUrl(undefined);
-      fetchGame(gameId)
-        .then((serverGame) => {
+
+      let cancelled = false;
+      let pollId: ReturnType<typeof setInterval> | undefined;
+
+      const load = async () => {
+        try {
+          const serverGame = await fetchGame(gameId);
+          if (cancelled) return false;
           setServerGameFromUrl({
             serverId: serverGame.id,
             pgn: serverGame.pgn,
@@ -142,18 +148,38 @@ export const useGameDatabase = (shouldFetchGames?: boolean) => {
                 }
               : undefined,
           });
-        })
-        .catch(() => setServerGameFromUrl(undefined));
-      return;
+          // The report is generated in the background; keep polling until the
+          // saved eval shows up so an opened "still analyzing" game fills in on
+          // its own (no manual reload, no foreground re-analysis).
+          return !!serverGame.eval;
+        } catch {
+          if (!cancelled) setServerGameFromUrl(undefined);
+          return false;
+        }
+      };
+
+      void load().then((hasEval) => {
+        if (cancelled || hasEval) return;
+        pollId = setInterval(async () => {
+          const done = await load();
+          if (done && pollId) clearInterval(pollId);
+        }, 5000);
+      });
+
+      return () => {
+        cancelled = true;
+        if (pollId) clearInterval(pollId);
+      };
     }
 
     setServerGameFromUrl(undefined);
     const localId = parseInt(gameId, 10);
     if (Number.isNaN(localId)) {
       setGameFromUrl(undefined);
-      return;
+      return undefined;
     }
     getGame(localId).then((game) => setGameFromUrl(game));
+    return undefined;
   }, [gameId, getGame]);
 
   const isReady = db !== null;

--- a/src/lib/engine/stockfish16.ts
+++ b/src/lib/engine/stockfish16.ts
@@ -11,7 +11,9 @@ export class Stockfish16 {
     }
 
     const multiThreadIsSupported = isMultiThreadSupported();
-    if (!multiThreadIsSupported) console.log("Single thread mode");
+    if (!multiThreadIsSupported && import.meta.env.DEV) {
+      console.log("Single thread mode");
+    }
 
     const enginePath = multiThreadIsSupported
       ? "engines/stockfish-16/stockfish-nnue-16.js"

--- a/src/lib/engine/stockfish16_1.ts
+++ b/src/lib/engine/stockfish16_1.ts
@@ -9,7 +9,9 @@ export class Stockfish16_1 {
     }
 
     const multiThreadIsSupported = isMultiThreadSupported();
-    if (!multiThreadIsSupported) console.log("Single thread mode");
+    if (!multiThreadIsSupported && import.meta.env.DEV) {
+      console.log("Single thread mode");
+    }
 
     const enginePath = `engines/stockfish-16.1/stockfish-16.1${
       lite ? "-lite" : ""

--- a/src/lib/engine/stockfish17.ts
+++ b/src/lib/engine/stockfish17.ts
@@ -9,7 +9,9 @@ export class Stockfish17 {
     }
 
     const multiThreadIsSupported = isMultiThreadSupported();
-    if (!multiThreadIsSupported) console.log("Single thread mode");
+    if (!multiThreadIsSupported && import.meta.env.DEV) {
+      console.log("Single thread mode");
+    }
 
     const enginePath = `engines/stockfish-17/stockfish-17${
       lite ? "-lite" : ""

--- a/src/lib/engine/uciEngine.ts
+++ b/src/lib/engine/uciEngine.ts
@@ -136,7 +136,9 @@ export class UciEngine {
   }
 
   private terminateWorker(worker: EngineWorker) {
-    console.log(`Terminating worker from ${this.enginePath}`);
+    if (import.meta.env.DEV) {
+      console.log(`Terminating worker from ${this.enginePath}`);
+    }
     worker.isReady = false;
     worker.uci("quit");
     worker.terminate();
@@ -388,8 +390,6 @@ export class UciEngine {
 
     await this.stopAllCurrentJobs();
     await this.setElo(elo);
-
-    console.log(`Evaluating position: ${fen}`);
 
     const results = await this.sendCommands(
       [`position fen ${fen}`, `go depth ${depth}`],

--- a/src/lib/engine/uciEngine.ts
+++ b/src/lib/engine/uciEngine.ts
@@ -11,7 +11,6 @@ import {
 } from "./helpers/parseResults";
 import { computeAccuracy } from "./helpers/accuracy";
 import { getIsStalemate, getWhoIsCheckmated } from "../chess";
-import { getLichessEval } from "../lichess";
 import { getMovesClassification } from "./helpers/moveClassification";
 import { computeEstimatedElo } from "./helpers/estimateElo";
 import { EngineWorker, WorkerJob } from "@/types/engine";
@@ -254,59 +253,66 @@ export class UciEngine {
     this.isReady = false;
     setEvaluationProgress?.(1);
 
-    await this.setMultiPv(multiPv);
-    await this.sendCommandsToEachWorker(["ucinewgame", "isready"], "readyok");
-    this.setWorkersNb(workersNb);
-
     const positions: PositionEval[] = new Array(fens.length);
-    let completed = 0;
 
-    const updateEval = (index: number, positionEval: PositionEval) => {
-      completed++;
-      positions[index] = positionEval;
-      const progress = completed / fens.length;
-      setEvaluationProgress?.(99 - Math.exp(-4 * progress) * 99);
-    };
+    try {
+      await this.setMultiPv(multiPv);
+      await this.sendCommandsToEachWorker(["ucinewgame", "isready"], "readyok");
+      await this.setWorkersNb(workersNb);
 
-    await Promise.all(
-      fens.map(async (fen, i) => {
-        const whoIsCheckmated = getWhoIsCheckmated(fen);
-        if (whoIsCheckmated) {
-          updateEval(i, {
-            lines: [
-              {
-                pv: [],
-                depth: 0,
-                multiPv: 1,
-                mate: whoIsCheckmated === "w" ? -1 : 1,
-              },
-            ],
-          });
-          return;
-        }
+      let completed = 0;
 
-        const isStalemate = getIsStalemate(fen);
-        if (isStalemate) {
-          updateEval(i, {
-            lines: [
-              {
-                pv: [],
-                depth: 0,
-                multiPv: 1,
-                cp: 0,
-              },
-            ],
-          });
-          return;
-        }
+      const updateEval = (index: number, positionEval: PositionEval) => {
+        completed++;
+        positions[index] = positionEval;
+        const progress = completed / fens.length;
+        setEvaluationProgress?.(99 - Math.exp(-4 * progress) * 99);
+      };
 
-        const result = await this.evaluatePosition(fen, depth, workersNb);
-        updateEval(i, result);
-      })
-    );
+      await Promise.all(
+        fens.map(async (fen, i) => {
+          const whoIsCheckmated = getWhoIsCheckmated(fen);
+          if (whoIsCheckmated) {
+            updateEval(i, {
+              lines: [
+                {
+                  pv: [],
+                  depth: 0,
+                  multiPv: 1,
+                  mate: whoIsCheckmated === "w" ? -1 : 1,
+                },
+              ],
+            });
+            return;
+          }
 
-    await this.setWorkersNb(1);
-    this.isReady = true;
+          const isStalemate = getIsStalemate(fen);
+          if (isStalemate) {
+            updateEval(i, {
+              lines: [
+                {
+                  pv: [],
+                  depth: 0,
+                  multiPv: 1,
+                  cp: 0,
+                },
+              ],
+            });
+            return;
+          }
+
+          const result = await this.evaluatePosition(fen, depth, workersNb);
+          updateEval(i, result);
+        })
+      );
+
+      await this.setWorkersNb(1);
+    } finally {
+      // Always restore readiness even if evaluation throws, so a single failed
+      // (or aborted) analysis never bricks the engine for the rest of the
+      // session.
+      this.isReady = true;
+    }
 
     const positionsWithClassification = getMovesClassification(
       positions,
@@ -336,18 +342,9 @@ export class UciEngine {
   private async evaluatePosition(
     fen: string,
     depth = 16,
-    workersNb: number
+    _workersNb?: number
   ): Promise<PositionEval> {
-    if (workersNb < 2) {
-      const lichessEval = await getLichessEval(fen, this.multiPv);
-      if (
-        lichessEval.lines.length >= this.multiPv &&
-        lichessEval.lines[0].depth >= depth
-      ) {
-        return lichessEval;
-      }
-    }
-
+    void _workersNb;
     const results = await this.sendCommands(
       [`position fen ${fen}`, `go depth ${depth}`],
       "bestmove"
@@ -364,8 +361,6 @@ export class UciEngine {
   }: EvaluatePositionWithUpdateParams): Promise<PositionEval> {
     this.throwErrorIfNotReady();
 
-    const lichessEvalPromise = getLichessEval(fen, multiPv);
-
     await this.stopAllCurrentJobs();
     await this.setMultiPv(multiPv);
 
@@ -374,17 +369,6 @@ export class UciEngine {
       const parsedResults = parseEvaluationResults(messages, fen);
       setPartialEval(parsedResults);
     };
-
-    console.log(`Evaluating position: ${fen}`);
-
-    const lichessEval = await lichessEvalPromise;
-    if (
-      lichessEval.lines.length >= multiPv &&
-      lichessEval.lines[0].depth >= depth
-    ) {
-      setPartialEval?.(lichessEval);
-      return lichessEval;
-    }
 
     const results = await this.sendCommands(
       [`position fen ${fen}`, `go depth ${depth}`],

--- a/src/lib/engine/worker.ts
+++ b/src/lib/engine/worker.ts
@@ -2,7 +2,9 @@ import { EngineWorker } from "@/types/engine";
 import { isIosDevice, isMobileDevice } from "./shared";
 
 export const getEngineWorker = (enginePath: string): EngineWorker => {
-  console.log(`Creating worker from ${enginePath}`);
+  if (import.meta.env.DEV) {
+    console.log(`Creating worker from ${enginePath}`);
+  }
 
   const worker = new window.Worker(enginePath);
 

--- a/src/sections/analysis/panel/ReportTabPanel.tsx
+++ b/src/sections/analysis/panel/ReportTabPanel.tsx
@@ -1,4 +1,4 @@
-import { Box, Button } from "@mui/material";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import { useCallback } from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import { Chess } from "chess.js";
@@ -30,7 +30,7 @@ export default function ReportTabPanel() {
   const game = useAtomValue(gameAtom);
   const gameEval = useAtomValue(gameEvalAtom);
   const progress = useAtomValue(evaluationProgressAtom);
-  const { reanalyzeGame, engineReady } = useAnalyzeGame();
+  const { reanalyzeGame, engineReady, isServerGame } = useAnalyzeGame();
   const { setPgn: setGamePgn } = useChessActions(gameAtom);
   const { resetToStartingPosition: resetBoard } = useChessActions(boardAtom);
   const setEval = useSetAtom(gameEvalAtom);
@@ -49,13 +49,46 @@ export default function ReportTabPanel() {
 
   const hasMoves = game.history().length > 0;
   const isAnalyzing = progress > 0;
-  const needsReanalysis = hasMoves && !gameEval && !isAnalyzing;
+  // A synced game whose report hasn't been saved yet: it's being generated in
+  // the background, so show a "preparing" notice (the page polls the server and
+  // fills in automatically) rather than the generic "load a game" empty state.
+  const serverReportPending = isServerGame && hasMoves && !gameEval;
+  const needsReanalysis =
+    hasMoves && !gameEval && !isAnalyzing && !isServerGame;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", width: "100%" }}>
       <EvaluationProgress />
 
-      {!gameEval && !isAnalyzing && <AnalysisEmptyState />}
+      {serverReportPending && !isAnalyzing && (
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            gap: 1.5,
+            p: 2,
+            mb: 1.5,
+            borderRadius: 1.5,
+            border: (t) => `1px dashed ${t.palette.divider}`,
+          }}
+        >
+          <CircularProgress size={22} />
+          <Box>
+            <Typography variant="body2" fontWeight={600}>
+              Preparing your report…
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              This game is being analyzed in the background. The report and move
+              classifications will appear here automatically — no need to
+              re-analyze.
+            </Typography>
+          </Box>
+        </Box>
+      )}
+
+      {!gameEval && !isAnalyzing && !serverReportPending && (
+        <AnalysisEmptyState />
+      )}
 
       {gameEval && (
         <>
@@ -85,7 +118,7 @@ export default function ReportTabPanel() {
         </>
       )}
 
-      {!gameEval && !isAnalyzing && (
+      {!gameEval && !isAnalyzing && !serverReportPending && (
         <ReportSection title="Evaluation graph" tourId="eval-graph" noPadding>
           <EvaluationGraphSection
             sticky={false}

--- a/src/sections/analysis/panelHeader/analyzeButton.tsx
+++ b/src/sections/analysis/panelHeader/analyzeButton.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useAnalyzeGame } from "@/hooks/useAnalyzeGame";
 import { useCurrentPosition } from "../hooks/useCurrentPosition";
 import { useEngine } from "@/hooks/useEngine";
-import { engineNameAtom, evaluationProgressAtom } from "../states";
+import { engineNameAtom, evaluationProgressAtom, gameAtom } from "../states";
 import { useAtomValue, useSetAtom } from "jotai";
 
 export default function AnalyzeButton() {
@@ -10,17 +10,32 @@ export default function AnalyzeButton() {
   const engine = useEngine(engineName);
   useCurrentPosition(engine);
   const setEvaluationProgress = useSetAtom(evaluationProgressAtom);
-  const { analyzeGame, readyToAnalyse, gameEval } = useAnalyzeGame();
+  const game = useAtomValue(gameAtom);
+  const { analyzeGame, readyToAnalyse, gameEval, isServerGame } =
+    useAnalyzeGame();
+
+  // Track which game we already kicked off analysis for, so a failed/aborted
+  // run does NOT re-trigger on the next render. Previously any failure left
+  // `gameEval` empty, which immediately satisfied the auto-analyze condition
+  // again — spawning Stockfish workers in an infinite loop.
+  const autoAnalyzedPgnRef = useRef<string | null>(null);
 
   useEffect(() => {
     setEvaluationProgress(0);
   }, [engine, setEvaluationProgress]);
 
   useEffect(() => {
-    if (!gameEval && readyToAnalyse) {
-      analyzeGame();
-    }
-  }, [gameEval, readyToAnalyse, analyzeGame]);
+    if (gameEval) return;
+    // Synced game reports are produced in the background and saved on the
+    // server; opening one must never start a foreground re-analysis.
+    if (isServerGame) return;
+    if (!readyToAnalyse) return;
+
+    const pgn = game.pgn();
+    if (!pgn || autoAnalyzedPgnRef.current === pgn) return;
+    autoAnalyzedPgnRef.current = pgn;
+    void analyzeGame();
+  }, [gameEval, isServerGame, readyToAnalyse, analyzeGame, game]);
 
   return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the broken game-report experience: opening a synced game now shows its saved report + per-move classifications instantly with no re-analysis, the infinite analyze/reload loop is gone, and the CORS console errors are eliminated.

## Walkthrough

Opening an already-analyzed synced game shows the saved report immediately (no "Analyzing…" bar, no re-analysis), and stepping through moves shows their classifications:

[open_synced_report_no_reanalyze.mp4](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fopen_synced_report_no_reanalyze.mp4)

[Synced report loads instantly with graph, accuracy and classification breakdown](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsynced_report_loads_instantly.webp)
[Stepping through moves shows classifications from saved data](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Freport_with_move_classifications.webp)

## Root causes & fixes

### 1. CORS errors on `lichess.org/api/cloud-eval` (`src/lib/engine/uciEngine.ts`)
The app sets `Cross-Origin-Embedder-Policy: require-corp` (needed for threaded Stockfish), which **blocks** the cross-origin Lichess cloud-eval fetch (it has no CORS/CORP headers) — the source of the console spam. Removed the cloud-eval lookups; evaluation uses the bundled Stockfish only.

### 2. Infinite analyze loop / "loads and reloads and repeats" (`src/sections/analysis/panelHeader/analyzeButton.tsx`)
The auto-analyze effect ran whenever there was no eval; a failed/aborted run left the eval empty, which immediately re-satisfied the condition → analysis re-triggered every render, spawning Stockfish workers forever. Auto-analyze now runs **at most once per loaded game** and never auto-retries on failure.

### 3. Opening synced games re-analyzed instead of using saved data
Synced (server) games are analyzed once in the background and their report is saved. Opening one now **never** starts a foreground re-analysis — it renders the saved report + per-move classifications. If the report isn't ready yet, a "Preparing your report…" notice is shown and the page polls so it fills in automatically once the background analysis completes (`src/hooks/useGameDatabase.ts`, `src/hooks/useAnalyzeGame.ts`, `src/sections/analysis/panel/ReportTabPanel.tsx`).

### 4. A failed analysis bricked the engine
`evaluateGame` now restores `isReady` in a `finally`, so one failed/aborted run can't disable analysis for the rest of the session.

### 5. Console noise
Verbose engine debug logs ("Creating worker", "Single thread mode", etc.) are gated to dev only.

## Saving model
The saved report already contains exactly what's needed — per-position evaluation **and** the move classification for every move (plus accuracy/ELO for the graph). The fix makes "Open" render that saved data directly, so there is no re-analysis on open.

## Responsive review
Reviewed the student hub and the analysis report page at phone (390px), tablet (820px), and desktop (1440px): both stack/grid cleanly with no overflow, cut-off text, or squished panels. The previously "broken" mobile look was the analysis page stuck in the loading/re-analyze loop, which this PR resolves.

## Testing
- `npm run lint` — clean
- `npm run build` — succeeds
- Manual (recorded): opened a synced, analyzed game → report shown instantly with move classifications; console free of cloud-eval/CORS/worker-spam/timeout; an un-analyzed game shows "Preparing…" and fills in via background analysis with no loop; responsive checked at phone/tablet/desktop.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

