### PR TITLE
Fix sync + analysis distribution: browser-authoritative, atomic claims, prompt sync

### DIFF
--- a/backend/sync/management/commands/run_platform_sync.py
+++ b/backend/sync/management/commands/run_platform_sync.py
@@ -13,12 +13,23 @@ class Command(BaseCommand):
         parser.add_argument(
             "--sync-only",
             action="store_true",
-            help="Only import games, skip Stockfish analysis",
+            help="(default behaviour) Only import games, skip server analysis",
+        )
+        parser.add_argument(
+            "--analyze",
+            action="store_true",
+            help=(
+                "Also run the server-side Stockfish analysis queue. Off by "
+                "default: server-side analysis is single-PV and cannot produce "
+                "the full report (accuracy / move classifications), and once a "
+                "game has any eval the student's browser stops analyzing it. "
+                "Prefer browser-side analysis for complete reports."
+            ),
         )
         parser.add_argument(
             "--analyze-only",
             action="store_true",
-            help="Only run server analysis queue",
+            help="Only run server analysis queue (implies --analyze)",
         )
         parser.add_argument(
             "--max-analyze",
@@ -28,6 +39,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        run_analysis = options["analyze"] or options["analyze_only"]
+
         if not options["analyze_only"]:
             links = (
                 CoachStudentLink.objects.filter(sync_enabled=True)
@@ -50,6 +63,11 @@ class Command(BaseCommand):
                         )
                     )
 
-        if not options["sync_only"]:
+        if run_analysis and not options["sync_only"]:
             result = process_server_queue(max_games=options["max_analyze"])
             self.stdout.write(self.style.SUCCESS(f"Server analysis: {result}"))
+        elif not run_analysis:
+            self.stdout.write(
+                "Skipping server-side analysis (browser-authoritative). "
+                "Pass --analyze to opt in."
+            )

--- a/backend/sync/services.py
+++ b/backend/sync/services.py
@@ -16,7 +16,10 @@ from .platform_fetch import SYNC_GAME_LIMIT, fetch_platform_games
 User = get_user_model()
 
 PRESENCE_ONLINE_SECONDS = 120
-BROWSER_CLAIM_TIMEOUT = timedelta(minutes=8)
+# How long a browser "claim" is trusted before another worker may take the game
+# over. Kept short so a tab that is closed mid-analysis doesn't leave a game
+# stuck for a long time.
+BROWSER_CLAIM_TIMEOUT = timedelta(minutes=4)
 SERVER_PENDING_TIMEOUT = timedelta(minutes=3)
 
 
@@ -258,19 +261,69 @@ def games_pending_server_analysis(limit: int = 3) -> list[Game]:
     return eligible
 
 
-def claim_game_for_browser(game: Game) -> Game:
-    game.analysis_status = AnalysisStatus.IN_PROGRESS
-    game.analysis_source = "browser"
-    game.analysis_claimed_at = timezone.now()
-    game.save(
-        update_fields=[
-            "analysis_status",
-            "analysis_source",
-            "analysis_claimed_at",
-            "updated_at",
-        ]
-    )
-    return game
+def claim_game_for_browser(game_id, student) -> Game | None:
+    """Atomically claim a game for browser-side analysis.
+
+    Returns the claimed game, or None if it can't be claimed (already analyzed,
+    or another worker holds a fresh claim). Row-locking prevents two tabs / the
+    server queue from analyzing the same game at once.
+    """
+    now = timezone.now()
+    stale_claim = now - BROWSER_CLAIM_TIMEOUT
+
+    with transaction.atomic():
+        try:
+            game = Game.objects.select_for_update().get(
+                pk=game_id, owner=student
+            )
+        except Game.DoesNotExist:
+            return None
+
+        if hasattr(game, "eval"):
+            return None
+
+        already_claimed = (
+            game.analysis_status == AnalysisStatus.IN_PROGRESS
+            and game.analysis_claimed_at is not None
+            and game.analysis_claimed_at > stale_claim
+        )
+        if already_claimed:
+            return None
+
+        game.analysis_status = AnalysisStatus.IN_PROGRESS
+        game.analysis_source = "browser"
+        game.analysis_claimed_at = now
+        game.save(
+            update_fields=[
+                "analysis_status",
+                "analysis_source",
+                "analysis_claimed_at",
+                "updated_at",
+            ]
+        )
+        return game
+
+
+def release_game_for_retry(game_id, student) -> bool:
+    """Return an unfinished, browser-claimed game to PENDING so it can be picked
+    up again promptly (used when a browser worker fails or abandons a game)."""
+    with transaction.atomic():
+        try:
+            game = Game.objects.select_for_update().get(
+                pk=game_id, owner=student
+            )
+        except Game.DoesNotExist:
+            return False
+
+        if hasattr(game, "eval"):
+            return True
+
+        game.analysis_status = AnalysisStatus.PENDING
+        game.analysis_claimed_at = None
+        game.save(
+            update_fields=["analysis_status", "analysis_claimed_at", "updated_at"]
+        )
+        return True
 
 
 def mark_analysis_complete(game: Game, source: str) -> None:

--- a/backend/sync/services.py
+++ b/backend/sync/services.py
@@ -367,18 +367,28 @@ def student_sync_overview(student) -> dict:
             }
         )
 
-    games = Game.objects.filter(owner=student)
+    # Whether a saved eval (report) exists is the source of truth for
+    # "analyzed" — not analysis_status, which can drift (e.g. a tab closed
+    # mid-flight). This keeps a game that already has a report from being shown
+    # as perpetually "analyzing".
+    games = list(Game.objects.filter(owner=student).select_related("eval"))
+    analyzed = sum(1 for g in games if hasattr(g, "eval"))
+    not_analyzed = [g for g in games if not hasattr(g, "eval")]
+    in_progress = sum(
+        1 for g in not_analyzed if g.analysis_status == AnalysisStatus.IN_PROGRESS
+    )
+    failed = sum(
+        1 for g in not_analyzed if g.analysis_status == AnalysisStatus.FAILED
+    )
+    pending = len(not_analyzed) - in_progress - failed
+
     return {
         "platform_links": platform_links,
-        "games_total": games.count(),
-        "games_analyzed": games.filter(analysis_status=AnalysisStatus.COMPLETE).count(),
-        "games_pending": games.filter(analysis_status=AnalysisStatus.PENDING).count(),
-        "games_in_progress": games.filter(
-            analysis_status=AnalysisStatus.IN_PROGRESS
-        ).count(),
-        "games_failed": games.filter(
-            analysis_status=AnalysisStatus.FAILED
-        ).count(),
+        "games_total": len(games),
+        "games_analyzed": analyzed,
+        "games_pending": pending,
+        "games_in_progress": in_progress,
+        "games_failed": failed,
         "last_sync_at": max(
             (l.last_sync_at for l in links if l.last_sync_at),
             default=None,

--- a/backend/sync/tests.py
+++ b/backend/sync/tests.py
@@ -13,7 +13,7 @@ from academies.models import (
     PlatformChoice,
     SyncStatus,
 )
-from games.models import AnalysisStatus, Game
+from games.models import AnalysisStatus, Game, GameEval
 from sync.platform_fetch import FetchedGame
 from sync.services import (
     StudentPresence,
@@ -178,6 +178,54 @@ class ClaimCompleteTests(SyncFixtureMixin, APITestCase):
         game = self._make_pending_game(owner=self.other)
         self.client.force_authenticate(self.student)
         res = self.client.post(f"/api/sync/games/{game.id}/claim/")
+        self.assertEqual(res.status_code, 403)
+
+    def test_double_claim_returns_conflict(self):
+        game = self._make_pending_game()
+        self.client.force_authenticate(self.student)
+
+        first = self.client.post(f"/api/sync/games/{game.id}/claim/")
+        self.assertEqual(first.status_code, 200)
+
+        # A second claim while the first is still fresh must be rejected so two
+        # tabs don't analyze the same game.
+        second = self.client.post(f"/api/sync/games/{game.id}/claim/")
+        self.assertEqual(second.status_code, 409)
+
+    def test_claim_already_analyzed_returns_conflict(self):
+        game = self._make_pending_game()
+        GameEval.objects.create(
+            game=game,
+            positions=[{"lines": [{"cp": 0, "depth": 1, "multiPv": 1, "pv": []}]}],
+            accuracy={"white": 90, "black": 90},
+            settings={},
+        )
+        self.client.force_authenticate(self.student)
+        res = self.client.post(f"/api/sync/games/{game.id}/claim/")
+        self.assertEqual(res.status_code, 409)
+
+    def test_release_returns_game_to_pending(self):
+        game = self._make_pending_game()
+        self.client.force_authenticate(self.student)
+
+        self.client.post(f"/api/sync/games/{game.id}/claim/")
+        game.refresh_from_db()
+        self.assertEqual(game.analysis_status, AnalysisStatus.IN_PROGRESS)
+
+        res = self.client.post(f"/api/sync/games/{game.id}/release/")
+        self.assertEqual(res.status_code, 200)
+        game.refresh_from_db()
+        self.assertEqual(game.analysis_status, AnalysisStatus.PENDING)
+        self.assertIsNone(game.analysis_claimed_at)
+
+        # After release it can be claimed again (e.g. retried).
+        again = self.client.post(f"/api/sync/games/{game.id}/claim/")
+        self.assertEqual(again.status_code, 200)
+
+    def test_release_other_users_game_forbidden(self):
+        game = self._make_pending_game(owner=self.other)
+        self.client.force_authenticate(self.student)
+        res = self.client.post(f"/api/sync/games/{game.id}/release/")
         self.assertEqual(res.status_code, 403)
 
     def test_pending_analysis_lists_synced_games(self):

--- a/backend/sync/tests.py
+++ b/backend/sync/tests.py
@@ -94,6 +94,31 @@ class OverviewTests(SyncFixtureMixin, APITestCase):
         self.assertEqual(len(res.data["platform_links"]), 1)
         self.assertEqual(res.data["games_total"], 0)
 
+    def test_overview_counts_eval_as_analyzed_despite_status(self):
+        # A game that has a saved report must count as analyzed even if its
+        # analysis_status drifted (e.g. left as pending), so it isn't shown as
+        # perpetually "analyzing".
+        game = Game.objects.create(
+            owner=self.student,
+            pgn=DEMO_PGN,
+            source="lichess",
+            external_id="drift-1",
+            analysis_status=AnalysisStatus.PENDING,
+        )
+        GameEval.objects.create(
+            game=game,
+            positions=[{"lines": [{"cp": 0, "depth": 1, "multiPv": 1, "pv": []}]}],
+            accuracy={"white": 88, "black": 90},
+            settings={},
+        )
+        self.client.force_authenticate(self.student)
+        res = self.client.get("/api/sync/overview/")
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.data["games_total"], 1)
+        self.assertEqual(res.data["games_analyzed"], 1)
+        self.assertEqual(res.data["games_pending"], 0)
+        self.assertEqual(res.data["games_in_progress"], 0)
+
     def test_coach_overview_for_linked_student(self):
         self.client.force_authenticate(self.coach)
         res = self.client.get(

--- a/backend/sync/urls.py
+++ b/backend/sync/urls.py
@@ -6,6 +6,7 @@ from .views import (
     PendingAnalysisView,
     PresenceView,
     ProcessServerQueueView,
+    ReleaseAnalysisView,
     SyncOverviewView,
     SyncTriggerView,
 )
@@ -28,6 +29,11 @@ urlpatterns = [
         "sync/games/<uuid:game_id>/complete/",
         CompleteAnalysisView.as_view(),
         name="sync-complete-analysis",
+    ),
+    path(
+        "sync/games/<uuid:game_id>/release/",
+        ReleaseAnalysisView.as_view(),
+        name="sync-release-analysis",
     ),
     path(
         "sync/process-server/",

--- a/backend/sync/views.py
+++ b/backend/sync/views.py
@@ -15,6 +15,7 @@ from .services import (
     claim_game_for_browser,
     games_pending_browser_analysis,
     mark_analysis_complete,
+    release_game_for_retry,
     student_sync_overview,
     sync_all_enabled_links_for_student,
     sync_coach_student_link,
@@ -134,10 +135,30 @@ class ClaimAnalysisView(APIView):
         self.check_object_permissions(request, game)
         if request.user.pk != game.owner_id:
             return Response(status=status.HTTP_403_FORBIDDEN)
-        if hasattr(game, "eval"):
-            return Response({"detail": "Already analyzed."}, status=status.HTTP_400_BAD_REQUEST)
-        claim_game_for_browser(game)
-        return Response(GameDetailSerializer(game).data)
+
+        claimed = claim_game_for_browser(game.id, request.user)
+        if claimed is None:
+            # Already analyzed, or another tab/worker holds a fresh claim.
+            return Response(
+                {"detail": "Game is already analyzed or being analyzed."},
+                status=status.HTTP_409_CONFLICT,
+            )
+        return Response(GameDetailSerializer(claimed).data)
+
+
+class ReleaseAnalysisView(APIView):
+    """Return a claimed-but-unfinished game to the queue (browser gave up)."""
+
+    permission_classes = (permissions.IsAuthenticated, IsGameOwnerOrCoach)
+
+    def post(self, request, game_id):
+        game = get_object_or_404(Game, pk=game_id)
+        self.check_object_permissions(request, game)
+        if request.user.pk != game.owner_id:
+            return Response(status=status.HTTP_403_FORBIDDEN)
+
+        release_game_for_retry(game.id, request.user)
+        return Response({"game_id": str(game.id), "status": "released"})
 
 
 class CompleteAnalysisView(APIView):

--- a/src/components/PlatformSyncOrchestrator.tsx
+++ b/src/components/PlatformSyncOrchestrator.tsx
@@ -10,6 +10,7 @@ import {
   claimGameAnalysis,
   completeGameAnalysis,
   fetchPendingAnalysis,
+  releaseGameAnalysis,
   sendSyncPresence,
   triggerSync,
 } from "@/lib/api/sync";
@@ -18,13 +19,20 @@ import { evaluationProgressAtom } from "@/sections/analysis/states";
 import { useAtomValue } from "jotai";
 
 const PRESENCE_MS = 45_000;
-const SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
+// Check for newly played games often so a student's latest games show up without
+// waiting hours. We only actually hit the API when enough time has passed since
+// the last successful sync, and also whenever the tab regains focus.
+const SYNC_CHECK_MS = 5 * 60 * 1000;
+const SYNC_MIN_INTERVAL_MS = 15 * 60 * 1000;
 const ANALYSIS_POLL_MS = 20_000;
-const LAST_SYNC_KEY = "voltchess-last-platform-sync";
+const LAST_SYNC_KEY_PREFIX = "voltchess-last-platform-sync";
+// Safety cap so a persistent claim conflict can't spin the drain loop forever.
+const MAX_DRAIN_GAMES = 60;
 
 /**
- * Background worker for students: heartbeat, periodic import, browser-side analysis
- * when the tab is open and Stockfish is idle.
+ * Background worker for students: presence heartbeat, prompt game import, and
+ * browser-side analysis (the authoritative source of full reports) whenever the
+ * tab is open and Stockfish is idle.
  */
 export default function PlatformSyncOrchestrator() {
   const { user, isAuthenticated } = useAuth();
@@ -35,6 +43,7 @@ export default function PlatformSyncOrchestrator() {
 
   const isStudent =
     isAuthenticated && user?.role === UserRole.Student && ENABLE_AUTHENTICATION;
+  const userId = user?.id;
 
   useEffect(() => {
     if (!isStudent) return;
@@ -48,27 +57,44 @@ export default function PlatformSyncOrchestrator() {
     return () => window.clearInterval(presenceId);
   }, [isStudent, evaluationProgress]);
 
+  // Prompt import of newly played games: on mount, whenever the tab becomes
+  // visible/focused, and on a short timer (rate-limited to once per
+  // SYNC_MIN_INTERVAL). Keyed per-user so multiple accounts on one browser
+  // don't suppress each other's syncs.
   useEffect(() => {
     if (!isStudent) return;
 
-    const maybeSync = () => {
-      const last = Number(localStorage.getItem(LAST_SYNC_KEY) || 0);
-      if (Date.now() - last < SYNC_INTERVAL_MS) return;
+    const lastSyncKey = `${LAST_SYNC_KEY_PREFIX}:${userId ?? "me"}`;
+
+    const maybeSync = (force = false) => {
+      const last = Number(localStorage.getItem(lastSyncKey) || 0);
+      if (!force && Date.now() - last < SYNC_MIN_INTERVAL_MS) return;
       void triggerSync()
         .then(() => {
-          localStorage.setItem(LAST_SYNC_KEY, String(Date.now()));
+          localStorage.setItem(lastSyncKey, String(Date.now()));
           qc.invalidateQueries({ queryKey: ["sync-overview"] });
           qc.invalidateQueries({ queryKey: ["my-games"] });
         })
         .catch(() => {
-          /* coach may not have set platform yet */
+          /* platform/username may not be set yet */
         });
     };
 
+    const onVisible = () => {
+      if (document.visibilityState === "visible") maybeSync();
+    };
+
     maybeSync();
-    const syncId = window.setInterval(maybeSync, SYNC_INTERVAL_MS);
-    return () => window.clearInterval(syncId);
-  }, [isStudent, qc]);
+    const syncId = window.setInterval(maybeSync, SYNC_CHECK_MS);
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+
+    return () => {
+      window.clearInterval(syncId);
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [isStudent, userId, qc]);
 
   useEffect(() => {
     if (!isStudent || !engine?.getIsReady()) return;
@@ -76,23 +102,25 @@ export default function PlatformSyncOrchestrator() {
 
     let cancelled = false;
 
-    const runQueue = async () => {
-      if (cancelled || analyzingRef.current || evaluationProgress) return;
-      if (!engine?.getIsReady()) return;
+    const analyzeOne = async (): Promise<"done" | "empty" | "stop"> => {
+      const pending = await fetchPendingAnalysis(1);
+      const game = pending[0];
+      if (!game?.pgn) return "empty";
+
+      // Atomically claim the game; if another tab/worker beat us to it, the
+      // server responds 409 and we just move on.
+      try {
+        await claimGameAnalysis(game.id);
+      } catch {
+        return "stop";
+      }
 
       try {
-        const pending = await fetchPendingAnalysis(1);
-        const game = pending[0];
-        if (!game?.pgn) return;
-
-        analyzingRef.current = true;
-        await claimGameAnalysis(game.id);
-
         const chess = new Chess();
         chess.loadPgn(game.pgn);
         const params = getEvaluateGameParams(chess);
 
-        const evalResult = await engine.evaluateGame({
+        const evalResult = await engine!.evaluateGame({
           ...params,
           depth: ENGINE_DEFAULTS.depth,
           multiPv: ENGINE_DEFAULTS.multiPv,
@@ -112,8 +140,29 @@ export default function PlatformSyncOrchestrator() {
 
         qc.invalidateQueries({ queryKey: ["sync-overview"] });
         qc.invalidateQueries({ queryKey: ["my-games"] });
+        return "done";
       } catch {
-        /* skip failed game; server queue may pick it up */
+        // Hand the game back so it's retried promptly instead of being stuck
+        // as "in progress" until the claim times out.
+        await releaseGameAnalysis(game.id).catch(() => {});
+        return "stop";
+      }
+    };
+
+    // Drain the queue: analyze pending games back-to-back while the tab is open
+    // and the engine is idle, yielding immediately if the user starts a
+    // foreground analysis.
+    const runQueue = async () => {
+      if (cancelled || analyzingRef.current || evaluationProgress) return;
+      if (!engine?.getIsReady()) return;
+
+      analyzingRef.current = true;
+      try {
+        for (let i = 0; i < MAX_DRAIN_GAMES; i++) {
+          if (cancelled || evaluationProgress || !engine?.getIsReady()) break;
+          const result = await analyzeOne();
+          if (result !== "done") break;
+        }
       } finally {
         analyzingRef.current = false;
       }

--- a/src/lib/api/sync.ts
+++ b/src/lib/api/sync.ts
@@ -75,6 +75,11 @@ export async function claimGameAnalysis(
   return res.data;
 }
 
+/** Return a claimed-but-unfinished game to the queue (browser gave up). */
+export async function releaseGameAnalysis(gameId: string): Promise<void> {
+  await api.post(`/api/sync/games/${gameId}/release/`);
+}
+
 export async function completeGameAnalysis(
   gameId: string,
   evalPayload: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a cluster of bugs in how games sync and how analysis is distributed between the student's browser and the Pi server.

## Walkthrough

The student's browser now drains the analysis queue back-to-back (here: "analyzing" goes 3 → 0 and "reports ready" rises to match "synced"):

[Before: games analyzing](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_draining_before.webp)
[After: queue fully drained, all reports ready](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_draining_after.webp)

## Bugs fixed

### 1. Server-side analysis produced incomplete reports that permanently broke games
The Pi/server Stockfish path is single-PV and stored an eval with **zero accuracy and no move classifications**. Because the browser skips any game that already has an eval (`if hasattr(game, "eval"): continue`), a server-analyzed game was stuck with a broken report forever. The Pi cron (`run_platform_sync`) now **imports only by default**; server analysis is opt-in via `--analyze`. Browser analysis is the authoritative source of complete reports.

### 2. Racy claims / games stuck "in progress"
- `claim_game_for_browser` is now atomic (`select_for_update`) and refuses games that are already analyzed or hold a fresh claim from another tab/worker — so two clients can't analyze the same game. The claim endpoint returns `409` on conflict.
- New **release** endpoint (`/api/sync/games/<id>/release/`) returns a claimed-but-unfinished game to `PENDING` so a failed/abandoned browser run is retried promptly instead of waiting out the claim timeout (also shortened 8m → 4m).

### 3. New games weren't detected for hours
The orchestrator synced only every 6h. It now imports on mount, whenever the tab regains focus/visibility, and every 15 min (rate-limited), keyed per-user.

### 4. Analysis trickled one game per 20s
The orchestrator now **drains** the queue — analyzing pending games back-to-back while the tab is open and the engine is idle — and yields immediately to a foreground analysis. On failure it releases the game for retry.

### 5. A report could show as perpetually "analyzing"
`student_sync_overview` counted by `analysis_status`, which can drift out of sync with reality. It now counts a game as analyzed when a **saved report exists** (`has_eval`), so a finished report is never shown as stuck "analyzing."

## Testing
- `backend/.venv/bin/python backend/manage.py test sync` — 20 passed (added: atomic double-claim 409, claim-already-analyzed 409, release→pending→reclaim, release ownership, eval-counts-as-analyzed)
- `npm run lint` — clean
- `npm run build` — succeeds
- Manual: queued 5 then 8 pending games; the browser drained them to completion (DB: pending→0, all with browser evals; backend log shows `claim`→`complete` 200s); counts reach reports-ready == synced, 0 analyzing.

[distribution_backend_log.txt](https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdistribution_backend_log.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5ae0edd-3ddc-4dd3-a858-15546004de6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

