### PR TITLE
Fix student hub: order reports by latest game date; reliable average accuracy

### DIFF
--- a/src/lib/api/games.ts
+++ b/src/lib/api/games.ts
@@ -17,6 +17,8 @@ export type ServerGame = {
   analysis_status?: "pending" | "in_progress" | "complete" | "failed";
   analysis_source?: "browser" | "server" | "";
   external_url?: string;
+  /** When the game was actually played (set for platform-synced games). */
+  platform_played_at?: string | null;
   created_at: string;
 };
 

--- a/src/pages/student/index.tsx
+++ b/src/pages/student/index.tsx
@@ -42,6 +42,25 @@ function gameDate(g: ServerGame): string {
   return isNaN(d.getTime()) ? "" : d.toLocaleDateString();
 }
 
+/**
+ * Best available "when was this game played" moment, as a sortable number (ms).
+ * Prefers the platform play time, then the PGN date, then the import time — so
+ * games order by recency of the actual game, not by when it was synced.
+ */
+function gamePlayedAt(g: ServerGame): number {
+  const candidates = [
+    g.platform_played_at,
+    g.date && g.date !== "????.??.??" ? g.date.replace(/\./g, "-") : null,
+    g.created_at,
+  ];
+  for (const c of candidates) {
+    if (!c) continue;
+    const t = new Date(c).getTime();
+    if (!isNaN(t)) return t;
+  }
+  return 0;
+}
+
 function StatTile({
   label,
   value,
@@ -117,24 +136,35 @@ export default function StudentHome() {
   const myAssignments = assignments.filter((a) => a.student.id === user?.id);
   const openAssignments = myAssignments.filter((a) => a.status !== "completed");
 
-  // Analyzed reports first, then the rest, newest first within each group.
+  // Newest game first, regardless of whether it has been analyzed yet.
   const sortedGames = useMemo(() => {
-    return [...games].sort((a, b) => {
-      if (a.has_eval !== b.has_eval) return a.has_eval ? -1 : 1;
-      return (b.created_at ?? "").localeCompare(a.created_at ?? "");
-    });
+    return [...games].sort((a, b) => gamePlayedAt(b) - gamePlayedAt(a));
   }, [games]);
 
-  const avgAcc =
-    stats &&
-    (stats.avg_accuracy_white != null || stats.avg_accuracy_black != null)
-      ? Math.round(
-          ((stats.avg_accuracy_white ?? 0) + (stats.avg_accuracy_black ?? 0)) /
-            ([stats.avg_accuracy_white, stats.avg_accuracy_black].filter(
-              (v) => v != null
-            ).length || 1)
-        )
-      : null;
+  // Average accuracy across the user's games. Prefer the backend summary; if it
+  // isn't available (stats still loading, or it returned no average), fall back
+  // to averaging the per-game accuracy already loaded with the games so the tile
+  // still shows a number whenever any analyzed game exists.
+  const avgAcc = useMemo(() => {
+    const fromStats =
+      stats &&
+      (stats.avg_accuracy_white != null || stats.avg_accuracy_black != null)
+        ? Math.round(
+            ((stats.avg_accuracy_white ?? 0) +
+              (stats.avg_accuracy_black ?? 0)) /
+              ([stats.avg_accuracy_white, stats.avg_accuracy_black].filter(
+                (v) => v != null
+              ).length || 1)
+          )
+        : null;
+    if (fromStats != null) return fromStats;
+
+    const perGame = games
+      .map((g) => gameAccuracy(g))
+      .filter((v): v is number => v != null);
+    if (!perGame.length) return null;
+    return Math.round(perGame.reduce((a, b) => a + b, 0) / perGame.length);
+  }, [stats, games]);
 
   const openAssignmentPgn = async (pgn: string) => {
     if (!pgn) return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two bugs on the **student hub** (`/student`) reported from a screen recording:

1. **Game reports were ordered by analysis status, not date.** The "My reports" list put analyzed games first, so a freshly-synced (not-yet-analyzed) newer game sank below older analyzed ones. Now the list sorts purely by **when the game was played, newest first**, regardless of analysis status — using the best available timestamp (`platform_played_at` → PGN `date` → import time).
2. **"Avg accuracy" tile showed a dash even with analyzed games.** The tile depended solely on the backend stats summary and had no fallback. It now falls back to averaging the per-game accuracy already loaded with the games, so it reliably shows a number whenever any analyzed game has accuracy.

Also added the `platform_played_at` field to the `ServerGame` type (it was already returned by the API but missing from the type).

### Files
- `src/pages/student/index.tsx` — date-based sort (`gamePlayedAt`) + resilient `avgAcc` computation.
- `src/lib/api/games.ts` — added `platform_played_at` to `ServerGame`.

## Testing
- ✅ `npm run lint` (green)
- ✅ `npm run build`
- ✅ Manual end-to-end: logged in as the demo student, seeded games across several dates with the **newest one left unanalyzed**; verified it sorts to the top above older analyzed games, and the average shows a number. A background platform-sync also imported real Lichess games, so the ordering was validated across 33 mixed analyzed/unanalyzed games.

## Walkthrough
[Student hub: avg accuracy shows 78% and the 6/19 unanalyzed game sorts above older analyzed games](https://cursor.com/agents/bc-85c02edc-eb70-4de4-b482-1e1274762bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstudent_hub_fixed_order_and_average.webp)

The summary shows **Avg accuracy 78%**, and the reports are ordered newest-first: the `6/19/2026` *Analyzing* (unanalyzed) game is first, above the `6/18` and `6/15` analyzed games, then older `4/8` and `3/17` imports.

[voltchess_student_hub_sorting_and_average_fix.mp4](https://cursor.com/agents/bc-85c02edc-eb70-4de4-b482-1e1274762bfc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvoltchess_student_hub_sorting_and_average_fix.mp4)

## Note on the third item (cookies / sign-in)
I couldn't access the screen recording (`c:\Users\jegan\...` is on your local machine, not reachable from the cloud VM), and the app has no cookie-based code — authentication uses JWT tokens in `localStorage`. Sign-in worked correctly during testing (the student logged in and the hub loaded). The recent auth rework (PR #20) reworked the login/registration flow and session persistence, which likely addresses earlier sign-in issues. If a sign-in/session problem remains, details on the exact symptom would let me fix it precisely.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-85c02edc-eb70-4de4-b482-1e1274762bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-85c02edc-eb70-4de4-b482-1e1274762bfc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

